### PR TITLE
Skip setting non-existent 're' option in vim <7.4

### DIFF
--- a/syntax/include/yaml.vim
+++ b/syntax/include/yaml.vim
@@ -17,7 +17,9 @@ endif
 
 let s:cpo_save = &cpo
 set cpo&vim
-setl re=0
+if exists("&re")
+  setl re=0
+endif
 
 " Allows keyword matches containing -
 setl iskeyword+=-


### PR DESCRIPTION
The 'regexpengine' or 're' option is new in vim 7.4.  Vim 7.3 and older will complain that the option doesn't exist if you try to set it.

The 're=0' setting was added in commit b608d4c to resolve issue #11.
