### PR TITLE
Issue #16: Strings get wrong colors

### DIFF
--- a/syntax/include/yaml.vim
+++ b/syntax/include/yaml.vim
@@ -36,9 +36,9 @@ syn match   yamlDelimiter       "[-,:]\s*" contained
 
 syn match   yamlBlock           "[\[\]\{\}>|]"
 syn match   yamlOperator        '[?+-]'
-syn region  yamlMapping        start='\w\+\%(\s\+\w\+\)*\s*\ze:' end='$' keepend oneline contains=yamlKey,yamlScalar
-syn match   yamlScalar         '\%(\W*\w\+\)\{2,}' contained contains=yamlTimestamp,yamlString,@yamlTypes,yamlBlock
-syn cluster yamlTypes          contains=yamlInteger,yamlFloating,yamlNumber,yamlBoolean,yamlConstant,yamlNull,yamlTime
+syn region  yamlMapping        start='\w\+\%(\s\+\w\+\)*\s*\ze:' end='\%(\ze[,}]\|$\)' keepend oneline contains=yamlKey,@yamlTypes,yamlScalar
+syn match   yamlScalar         '\%(\s*\w\+\)\{2,}' contained contains=yamlTimestamp,@yamlTypes,yamlBlock
+syn cluster yamlTypes          contains=yamlString,yamlInteger,yamlFloating,yamlNumber,yamlBoolean,yamlConstant,yamlNull,yamlTime,yamlComment
 syn match   yamlKey            '\w\+\%(\s\+\w\+\)*\s*:' contained nextgroup=@yamlTypes contains=yamlDelimiter
 
 " Predefined data types


### PR DESCRIPTION
This quick fix improves the highlighting for the example in #16.

I do not think that `with_items` has anything to do with the problem here.  The reason the strings are not highlighted is that the `yamlScalar` syntax group does not allow `yamlString` inside it; this patch changes that.

A more complete solution to the problem would be to recognize `{ name: 'Jinja2', version: '2.7.1' }` as a flow hash (two keys, each with a value).  I do not think this can be done with a quick fix.
