### PR TITLE
Activate syntax for any file in vars directories

### DIFF
--- a/ftdetect/ansible.vim
+++ b/ftdetect/ansible.vim
@@ -3,17 +3,18 @@
 " Maintainer:      Benji Fisher, Ph.D. <benji@FisherFam.org>
 " Author:          Chase Colman <chase@colman.io>
 " Version:         1.0
-" Latest Revision: 2014-11-10
+" Latest Revision: 2015-02-03
 " URL:             https://github.com/chase/vim-ansible-yaml
 
-autocmd BufNewFile,BufRead *.yml  call s:SelectAnsible()
+autocmd BufNewFile,BufRead *.yml,*/{group,host}_vars/*  call s:SelectAnsible()
 
 fun! s:SelectAnsible()
   let fp = expand("<afile>:p")
   let dir = expand("<afile>:p:h")
 
   " Check if buffer is file under any directory of a 'roles' directory
-  if fp =~ '/roles/.*\.yml$'
+  " or under any *_vars directory
+  if fp =~ '/roles/.*\.yml$' || fp =~ '/\(group\|host\)_vars/'
     set filetype=ansible
     return
   endif

--- a/ftdetect/ansible.vim
+++ b/ftdetect/ansible.vim
@@ -3,12 +3,17 @@
 " Maintainer:      Benji Fisher, Ph.D. <benji@FisherFam.org>
 " Author:          Chase Colman <chase@colman.io>
 " Version:         1.0
-" Latest Revision: 2015-02-03
+" Latest Revision: 2015-03-23
 " URL:             https://github.com/chase/vim-ansible-yaml
 
 autocmd BufNewFile,BufRead *.yml,*/{group,host}_vars/*  call s:SelectAnsible()
 
 fun! s:SelectAnsible()
+  " Bail out if 'filetype' is already set to "ansible".
+  if index(split(&ft, '\.'), 'ansible') != -1
+    return
+  endif
+
   let fp = expand("<afile>:p")
   let dir = expand("<afile>:p:h")
 


### PR DESCRIPTION
Hi,

This is a simple PR to enable automatic syntax detection for vars files under **group_vars** and **host_vars** (see http://docs.ansible.com/playbooks_best_practices.html#directory-layout).