### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
After helptags are generated, a /doc/tags file is created. This puts the
directory in a permanent state of modification. If you do not wish to
commit the tags, it becomes especially intrusive when using git submodules for
vim plugins.