### PR TITLE
Indentation fix

### DIFF
--- a/indent/ansible.vim
+++ b/indent/ansible.vim
@@ -42,6 +42,8 @@ function GetAnsibleIndent(lnum)
     return indent
   elseif prevline =~ ':\s*[>|]?$'
     return increase
+  elseif prevline =~ ':$'
+    return increase
   elseif prevline =~ '^\s*-\s*$'
     return increase
   elseif prevline =~ '^\s*-\s\+[^:]\+:\s*\S'


### PR DESCRIPTION
It's smal fix for indentation like:
 - name: service start
   service:
     name: xxxx
     state: restarted

Next line after `service:` not indented and it's a bug.