### PR TITLE
Make the ansible documentation mapping optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Adds additional syntax highlighting and fixes indentation for Ansible's dialect of YAML.
 
 Allows the use of the K key in normal mode to search the ansible docs for the keyword underneath the current
-cursor position.
+cursor position. Set this option in your vimrc to enable: `let g:ansible_doc_mapping = 1`.
 
 Ansible YAML files are detected based on the presence of a modeline or a
 [structure following Ansible's Playbook Best Practices](http://www.ansibleworks.com/docs/playbooks_best_practices.html#directory-layout).

--- a/ftplugin/ansible.vim
+++ b/ftplugin/ansible.vim
@@ -23,6 +23,8 @@ let &cpo = s:save_cpo
 unlet s:save_cpo
 
 " Remap K to look in ansible-doc for keyword under cursor
-nmap K :!ansible-doc <C-R><C-W> *<CR>
+if exists("g:ansible_doc_mapping")
+  nmap K :!ansible-doc <C-R><C-W> *<CR>
+endif
 
 " vim:sts=2:sw=2:


### PR DESCRIPTION
Remapping a user's keys in vim without asking first is a big no no - and would cause very unreliable behavior if all plugins did this.

This PR makes the documentation mapping (of 'K') optional through a toggle the user can set.