### PR TITLE
Fix filetype detection on Windows

### DIFF
--- a/ftdetect/ansible.vim
+++ b/ftdetect/ansible.vim
@@ -6,7 +6,7 @@
 " Latest Revision: 2015-03-23
 " URL:             https://github.com/chase/vim-ansible-yaml
 
-autocmd BufNewFile,BufRead *.yml,*.yaml,*/{group,host}_vars/*  call s:SelectAnsible("ansible")
+autocmd BufNewFile,BufRead */roles/*.{yml,yaml},*/{group,host}_vars/* execute "set filetype=ansible"
 autocmd BufNewFile,BufRead hosts call s:SelectAnsible("ansible_hosts")
 
 fun! s:SelectAnsible(fileType)
@@ -17,13 +17,6 @@ fun! s:SelectAnsible(fileType)
 
   let fp = expand("<afile>:p")
   let dir = expand("<afile>:p:h")
-
-  " Check if buffer is file under any directory of a 'roles' directory
-  " or under any *_vars directory
-  if fp =~ '/roles/.*\.y\(a\)\?ml$' || fp =~ '/\(group\|host\)_vars/'
-    execute "set filetype=" . a:fileType
-    return
-  endif
 
   " Check if subdirectories in buffer's directory match Ansible best practices
   if v:version < 704


### PR DESCRIPTION
expand() returns backslashes on Windows, but the regular expression was expecting forward slashes only.
autocmd should be able to do everything the removed code was doing, and it works on Windows too.